### PR TITLE
Don't display method names or example values

### DIFF
--- a/src/Xbehave.Net40/ScenarioAttribute.cs
+++ b/src/Xbehave.Net40/ScenarioAttribute.cs
@@ -99,7 +99,7 @@ namespace Xbehave
             }
 
             var commands = new List<ICommand>();
-            var exampleIndex = 0;
+            var index = 0;
             foreach (var arguments in GetArgumentCollections(method.MethodInfo))
             {
                 var closedTypeMethod = method;
@@ -140,7 +140,7 @@ namespace Xbehave
                     generatedArguments.Add(new Argument(parameterType));
                 }
 
-                var methodCall = new MethodCall(closedTypeMethod, arguments.Concat(generatedArguments).ToArray(), typeArguments, ++exampleIndex);
+                var methodCall = new MethodCall(closedTypeMethod, arguments.Concat(generatedArguments).ToArray(), typeArguments, ++index);
                 commands.Add(new Command(methodCall));
             }
 

--- a/src/Xbehave.Net40/ScenarioAttribute.cs
+++ b/src/Xbehave.Net40/ScenarioAttribute.cs
@@ -99,6 +99,7 @@ namespace Xbehave
             }
 
             var commands = new List<ICommand>();
+            var exampleIndex = 0;
             foreach (var arguments in GetArgumentCollections(method.MethodInfo))
             {
                 var closedTypeMethod = method;
@@ -139,7 +140,8 @@ namespace Xbehave
                     generatedArguments.Add(new Argument(parameterType));
                 }
 
-                commands.Add(new Command(new MethodCall(closedTypeMethod, arguments.Concat(generatedArguments).ToArray(), typeArguments)));
+                var methodCall = new MethodCall(closedTypeMethod, arguments.Concat(generatedArguments).ToArray(), typeArguments, ++exampleIndex);
+                commands.Add(new Command(methodCall));
             }
 
             return commands;

--- a/src/Xbehave.Sdk.Net40/Command.cs
+++ b/src/Xbehave.Sdk.Net40/Command.cs
@@ -93,7 +93,17 @@ namespace Xbehave.Sdk
                 parameterTokens.Add(parameters[parameterIndex].Name + ": ???");
             }
 
-            return string.Format(CultureInfo.InvariantCulture, "{0}({1})", csharp, string.Join(", ", parameterTokens.ToArray()));
+            var format = string.Empty;
+            if (CurrentScenario.ShowMethod)
+            {
+                format = "{0}";
+            }
+            if (CurrentScenario.ShowExample)
+            {
+                format += "({1})";
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, format, csharp, string.Join(", ", parameterTokens.ToArray()));
         }
 
         private static string GetString(Type type)

--- a/src/Xbehave.Sdk.Net40/Command.cs
+++ b/src/Xbehave.Sdk.Net40/Command.cs
@@ -9,7 +9,6 @@ namespace Xbehave.Sdk
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
-    using System.Threading;
     using Xunit.Sdk;
 
     public class Command : TestCommand, ICommand
@@ -62,45 +61,52 @@ namespace Xbehave.Sdk
 
         private static string GetString(IMethodInfo method, Argument[] arguments, Type[] typeArguments)
         {
-            var csharp = string.Concat(method.TypeName, ".", method.Name);
-            if (typeArguments.Length > 0)
+            if (!CurrentScenario.ShowMethod && !CurrentScenario.ShowExample)
             {
-                csharp = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "{0}<{1}>",
-                    csharp,
-                    string.Join(", ", typeArguments.Select(typeArgument => GetString(typeArgument)).ToArray()));
-            }
-
-            var parameters = method.MethodInfo.GetParameters();
-            var parameterTokens = new List<string>();
-            int parameterIndex;
-            for (parameterIndex = 0; parameterIndex < arguments.Length; parameterIndex++)
-            {
-                if (arguments[parameterIndex].IsGeneratedDefault)
-                {
-                    continue;
-                }
-
-                parameterTokens.Add(string.Concat(
-                    parameterIndex >= parameters.Length ? "???" : parameters[parameterIndex].Name,
-                    ": ",
-                    GetString(arguments[parameterIndex])));
-            }
-
-            for (; parameterIndex < parameters.Length; parameterIndex++)
-            {
-                parameterTokens.Add(parameters[parameterIndex].Name + ": ???");
+                return string.Empty;
             }
 
             var format = string.Empty;
+            string csharp = null;
             if (CurrentScenario.ShowMethod)
             {
                 format = "{0}";
+
+                csharp = string.Concat(method.TypeName, ".", method.Name);
+                if (typeArguments.Length > 0)
+                {
+                    csharp = string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0}<{1}>",
+                        csharp,
+                        string.Join(", ", typeArguments.Select(typeArgument => GetString(typeArgument)).ToArray()));
+                }
             }
+
+            var parameterTokens = new List<string>();
             if (CurrentScenario.ShowExample)
             {
                 format += "({1})";
+
+                var parameters = method.MethodInfo.GetParameters();
+                int parameterIndex;
+                for (parameterIndex = 0; parameterIndex < arguments.Length; parameterIndex++)
+                {
+                    if (arguments[parameterIndex].IsGeneratedDefault)
+                    {
+                        continue;
+                    }
+
+                    parameterTokens.Add(string.Concat(
+                        parameterIndex >= parameters.Length ? "???" : parameters[parameterIndex].Name,
+                        ": ",
+                        GetString(arguments[parameterIndex])));
+                }
+
+                for (; parameterIndex < parameters.Length; parameterIndex++)
+                {
+                    parameterTokens.Add(parameters[parameterIndex].Name + ": ???");
+                }
             }
 
             return string.Format(CultureInfo.InvariantCulture, format, csharp, string.Join(", ", parameterTokens.ToArray()));

--- a/src/Xbehave.Sdk.Net40/ContextCommand.cs
+++ b/src/Xbehave.Sdk.Net40/ContextCommand.cs
@@ -18,8 +18,26 @@ namespace Xbehave.Sdk
             : base(methodCall)
         {
             var provider = CultureInfo.InvariantCulture;
-            this.Name = string.Format(provider, "[{0}.{1}]", contextOrdinal.ToString("D2", provider), commandOrdinal.ToString("D2", provider));
-            this.DisplayName = string.Format(provider, "{0} {1}", this.DisplayName, this.Name);
+
+            if (methodCall.Index != null && !CurrentScenario.ShowExample)
+            {
+                this.Name = string.Format(
+                    provider,
+                    "[{0}.{1}.{2}]",
+                    methodCall.Index.Value.ToString("D2", provider),
+                    contextOrdinal.ToString("D2", provider),
+                    commandOrdinal.ToString("D2", provider));
+            }
+            else
+            {
+                this.Name = string.Format(
+                    provider,
+                    "[{0}.{1}]",
+                    contextOrdinal.ToString("D2", provider),
+                    commandOrdinal.ToString("D2", provider));
+            }
+
+            this.DisplayName = string.Format(provider, "{0} {1}", this.DisplayName, this.Name).Trim();
         }
 
         public string Name { get; protected set; }

--- a/src/Xbehave.Sdk.Net40/ContextCommand.cs
+++ b/src/Xbehave.Sdk.Net40/ContextCommand.cs
@@ -6,10 +6,6 @@ namespace Xbehave.Sdk
 {
     using System;
     using System.Globalization;
-    using System.Linq;
-    using System.Reflection;
-    using Xunit.Extensions;
-    using Xunit.Sdk;
 
     [CLSCompliant(false)]
     public abstract class ContextCommand : Command
@@ -37,7 +33,9 @@ namespace Xbehave.Sdk
                     commandOrdinal.ToString("D2", provider));
             }
 
-            this.DisplayName = string.Format(provider, "{0} {1}", this.DisplayName, this.Name).Trim();
+            this.DisplayName = string.IsNullOrEmpty(this.DisplayName)
+                                   ? this.Name
+                                   : string.Format(provider, "{0} {1}", this.DisplayName, this.Name);
         }
 
         public string Name { get; protected set; }

--- a/src/Xbehave.Sdk.Net40/CurrentScenario.cs
+++ b/src/Xbehave.Sdk.Net40/CurrentScenario.cs
@@ -27,6 +27,17 @@ namespace Xbehave.Sdk
             set { CurrentScenario.addingBackgroundSteps = value; }
         }
 
+        // Todo: make these configurable
+        public static bool ShowMethod
+        {
+            get { return false; }
+        }
+
+        public static bool ShowExample
+        {
+            get { return false; }
+        }
+
         private static List<Step> Steps
         {
             get { return steps ?? (steps = new List<Step>()); }
@@ -36,12 +47,6 @@ namespace Xbehave.Sdk
         {
             get { return teardowns ?? (teardowns = new List<Action>()); }
         }
-
-        // Todo: make these configurable
-
-        public static bool ShowMethod { get { return false; } }
-
-        public static bool ShowExample { get { return false; } }
 
         public static Step AddStep(string name, Action body)
         {

--- a/src/Xbehave.Sdk.Net40/CurrentScenario.cs
+++ b/src/Xbehave.Sdk.Net40/CurrentScenario.cs
@@ -37,6 +37,12 @@ namespace Xbehave.Sdk
             get { return teardowns ?? (teardowns = new List<Action>()); }
         }
 
+        // Todo: make these configurable
+
+        public static bool ShowMethod { get { return false; } }
+
+        public static bool ShowExample { get { return false; } }
+
         public static Step AddStep(string name, Action body)
         {
             var step = new Step(addingBackgroundSteps ? "(Background) " + name : name, body);

--- a/src/Xbehave.Sdk.Net40/MethodCall.cs
+++ b/src/Xbehave.Sdk.Net40/MethodCall.cs
@@ -11,11 +11,12 @@ namespace Xbehave.Sdk
 
     public class MethodCall
     {
+        private readonly int? index;
         private readonly IMethodInfo method;
         private readonly Argument[] arguments;
         private readonly Type[] typeArguments;
 
-        public MethodCall(IMethodInfo method, IEnumerable<Argument> arguments, IEnumerable<Type> typeArguments)
+        public MethodCall(IMethodInfo method, IEnumerable<Argument> arguments, IEnumerable<Type> typeArguments, int? index = null)
         {
             if (method == null)
             {
@@ -31,6 +32,8 @@ namespace Xbehave.Sdk
                 {
                     throw new ArgumentException("The arguments contain at least one null value.", "arguments");
                 }
+
+                this.index = index;
             }
             else
             {
@@ -49,6 +52,11 @@ namespace Xbehave.Sdk
             {
                 this.typeArguments = new Type[0];
             }
+        }
+
+        public int? Index
+        {
+            get { return this.index; }
         }
 
         public IMethodInfo Method

--- a/src/test/Xbehave.Features.Net40/ExampleFeature.cs
+++ b/src/test/Xbehave.Features.Net40/ExampleFeature.cs
@@ -144,7 +144,8 @@ namespace Xbehave.Test.Acceptance
                 .Then(() => results.Should().NotBeEmpty());
 
             "And the display name of each result should contain \"<Int32, Int64, String, Object, Object>\""
-                .And(() => results.Should().OnlyContain(result => result.DisplayName.Contains("<Int32, Int64, String, Object, Object>")));
+                .And(() => results.Should().OnlyContain(result => result.DisplayName.Contains("<Int32, Int64, String, Object, Object>")))
+                .Skip("No longer displaying example values");
         }
 
         [Scenario]


### PR DESCRIPTION
This keeps the display name short in favour of using formatting placeholders like {0} in the step names.

I've added 2 boolean values to CurrentScenario, if they are changed back to `true` it will revert back to the current way. We could make those configurable or stick with the new form.

(passes StyleCop settings)
